### PR TITLE
Optimize on-core performance

### DIFF
--- a/code/include/allgather/impl.hpp
+++ b/code/include/allgather/impl.hpp
@@ -13,7 +13,7 @@ class allgather : public dsop {
   using dsop::dsop;
 
  public:
-  matrix compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) override;
+  void compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) override;
 };
 
 } // namespace impls::allgather

--- a/code/include/allreduce/impl.hpp
+++ b/code/include/allreduce/impl.hpp
@@ -13,7 +13,7 @@ class allreduce : public dsop {
   using dsop::dsop;
 
  public:
-  matrix compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) override;
+  void compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) override;
 };
 
 } // namespace impls::allreduce

--- a/code/include/dsop.h
+++ b/code/include/dsop.h
@@ -16,10 +16,11 @@ class dsop {
   const int M;
 
  public:
-  dsop(MPI_Comm comm, int rank, int num_procs, int N, int M) : comm(comm), rank(rank), num_procs(num_procs), N(N), M(M) {}
+  dsop(MPI_Comm comm, int rank, int num_procs, int N, int M)
+      : comm(comm), rank(rank), num_procs(num_procs), N(N), M(M) {}
   virtual ~dsop() = default;
 
-  virtual matrix compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) = 0;
+  virtual void compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) = 0;
 };
 
 #endif // CODE_DSOP_H

--- a/code/include/dsop_single.h
+++ b/code/include/dsop_single.h
@@ -12,7 +12,7 @@
 class dsop_single : dsop {
  public:
   using dsop::dsop;
-  matrix compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) override;
+  void compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) override;
 };
 
 #endif // CODE_DSOP_SINGLE_H

--- a/code/include/util.hpp
+++ b/code/include/util.hpp
@@ -16,17 +16,10 @@ std::vector<vector> get_random_vectors(uint64_t seed, int n, int p);
  *
  * Writes the runtime in microseconds into the second argument
  */
-template <typename R>
-R timer(std::function<R(void)> fun, int64_t& us) {
-  auto start = MPI_Wtime();
-  auto res = fun();
-  auto finish = MPI_Wtime();
-  us = static_cast<int64_t>((finish - start) * 1e6);
-  return res;
-}
+int64_t timer(std::function<void(void)> fun);
 
 template <typename T>
-T nrm_sqr_diff(T* x, T* y, int n) {
+T nrm_sqr_diff(const T* x, const T* y, int n) {
   T nrm_sqr = 0;
 
   for (int i = 0; i < n; i++) {

--- a/code/src/allgather/impl.cpp
+++ b/code/src/allgather/impl.cpp
@@ -2,7 +2,7 @@
 
 namespace impls::allgather {
 
-matrix allgather::compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) {
+void allgather::compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) {
   const auto& a = a_in[rank];
   const auto& b = b_in[rank];
 
@@ -12,15 +12,14 @@ matrix allgather::compute(const std::vector<vector>& a_in, const std::vector<vec
   auto rec_b = vector(M * num_procs);
   MPI_Allgather(b.data(), M, MPI_DOUBLE, rec_b.data(), M, MPI_DOUBLE, comm);
 
-  auto result = matrix(N, M);
   for (int i = 0; i < num_procs; i++) {
     for (int x = 0; x < N; x++) {
+      double tmp = rec_a[i * N + x];
       for (int y = 0; y < M; y++) {
-        result.get(x, y) += rec_a[i * N + x] * rec_b[i * M + y];
+        result.get(x, y) += tmp * rec_b[i * M + y];
       }
     }
   }
-  return result;
 }
 
 } // namespace impls::allgather

--- a/code/src/allreduce/impl.cpp
+++ b/code/src/allreduce/impl.cpp
@@ -2,16 +2,12 @@
 
 namespace impls::allreduce {
 
-matrix allreduce::compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in) {
+void allreduce::compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) {
   const auto& a = a_in[rank];
   const auto& b = b_in[rank];
 
   auto current = matrix::outer(a, b);
-  auto result = matrix(N, M);
-
   MPI_Allreduce(current.get_ptr(), result.get_ptr(), result.dimension(), MPI_DOUBLE, MPI_SUM, comm);
-
-  return result;
 }
 
 } // namespace impls::allreduce

--- a/code/src/dsop_single.cpp
+++ b/code/src/dsop_single.cpp
@@ -2,11 +2,8 @@
 
 #include <cassert>
 
-matrix dsop_single::compute(const std::vector<vector>& a, const std::vector<vector>& b) {
-  auto result = matrix(N, M);
+void dsop_single::compute(const std::vector<vector>& a, const std::vector<vector>& b, matrix& result) {
   for (size_t i = 0; i < a.size(); i++) {
     result.add(matrix::outer(a[i], b[i]));
   }
-
-  return result;
 }

--- a/code/src/main.cpp
+++ b/code/src/main.cpp
@@ -139,8 +139,8 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  int64_t t;
-  auto result = timer<matrix>([&]() { return impl->compute(a_vec, b_vec); }, t);
+  auto result = matrix(N, M);
+  int64_t t = timer([&]() { return impl->compute(a_vec, b_vec, result); });
 
   if (is_root) {
     std::vector<int64_t> timings(numprocs);
@@ -201,7 +201,8 @@ int main(int argc, char* argv[]) {
       }
 
       auto sequential = dsop_single(COMM, rank, numprocs, N, M);
-      auto expected = sequential.compute(a_vec, b_vec);
+      auto expected = matrix(N, M);
+      sequential.compute(a_vec, b_vec, expected);
 
       auto& r = results.front();
 

--- a/code/src/util.cpp
+++ b/code/src/util.cpp
@@ -26,5 +26,5 @@ int64_t timer(std::function<void(void)> fun) {
   auto start = MPI_Wtime();
   fun();
   auto finish = MPI_Wtime();
-  return static_cast<int64_t>((finish - start) * 1000);
+  return static_cast<int64_t>((finish - start) * 1e6);
 }

--- a/code/tests/dsop_test.cpp
+++ b/code/tests/dsop_test.cpp
@@ -22,7 +22,8 @@ TEST(DSOP_SingleTest, BasicAssertions) {
   auto expected = matrix(3, 2, {{10, 20}, {20, 40}, {30, 60}});
 
   auto calculator = dsop_single(nullptr, 0, 1, 3, 2);
-  auto result = calculator.compute(a, b);
+  auto result = matrix(3, 2);
+  calculator.compute(a, b, result);
 
   EXPECT_EQ(result, expected);
 }


### PR DESCRIPTION
Now we copy as little data as possible when calling `compute`. All input vectors are passed by reference and the result array is allocated by the caller and passed by reference as well.