### PR TITLE
Time MPI calls

### DIFF
--- a/code/include/dsop.h
+++ b/code/include/dsop.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 #include "matrix.h"
+#include "util.hpp"
 
 // dsop is the interface that dsop implementations should satisfy
 class dsop {
@@ -15,12 +16,27 @@ class dsop {
   const int N;
   const int M;
 
+  int64_t mpi_time{0};
+
  public:
   dsop(MPI_Comm comm, int rank, int num_procs, int N, int M)
       : comm(comm), rank(rank), num_procs(num_procs), N(N), M(M) {}
   virtual ~dsop() = default;
 
   virtual void compute(const std::vector<vector>& a_in, const std::vector<vector>& b_in, matrix& result) = 0;
+
+  template <typename F, typename... Args>
+  auto mpi_timer(F& f, Args&&... args) {
+    timer t;
+    const auto& r = f(std::forward<Args>(args)...);
+    mpi_time += t.finish();
+
+    return r;
+  }
+
+  int64_t get_mpi_time() const {
+    return mpi_time;
+  }
 };
 
 #endif // CODE_DSOP_H

--- a/code/include/util.hpp
+++ b/code/include/util.hpp
@@ -16,7 +16,26 @@ std::vector<vector> get_random_vectors(uint64_t seed, int n, int p);
  *
  * Writes the runtime in microseconds into the second argument
  */
-int64_t timer(std::function<void(void)> fun);
+int64_t timer_run(std::function<void(void)> fun);
+
+class timer {
+ public:
+  timer() {
+    start_us = get_time();
+  };
+
+  int64_t finish() {
+    return get_time() - start_us;
+  }
+
+ protected:
+  int64_t get_time() {
+    return static_cast<int64_t>(MPI_Wtime() * 1e6);
+  }
+
+ private:
+  int64_t start_us{0};
+};
 
 template <typename T>
 T nrm_sqr_diff(const T* x, const T* y, int n) {

--- a/code/src/allgather/impl.cpp
+++ b/code/src/allgather/impl.cpp
@@ -7,10 +7,10 @@ void allgather::compute(const std::vector<vector>& a_in, const std::vector<vecto
   const auto& b = b_in[rank];
 
   auto rec_a = vector(N * num_procs);
-  MPI_Allgather(a.data(), N, MPI_DOUBLE, rec_a.data(), N, MPI_DOUBLE, comm);
+  mpi_timer(MPI_Allgather, a.data(), N, MPI_DOUBLE, rec_a.data(), N, MPI_DOUBLE, comm);
 
   auto rec_b = vector(M * num_procs);
-  MPI_Allgather(b.data(), M, MPI_DOUBLE, rec_b.data(), M, MPI_DOUBLE, comm);
+  mpi_timer(MPI_Allgather, b.data(), M, MPI_DOUBLE, rec_b.data(), M, MPI_DOUBLE, comm);
 
   for (int i = 0; i < num_procs; i++) {
     for (int x = 0; x < N; x++) {

--- a/code/src/allreduce/impl.cpp
+++ b/code/src/allreduce/impl.cpp
@@ -7,7 +7,7 @@ void allreduce::compute(const std::vector<vector>& a_in, const std::vector<vecto
   const auto& b = b_in[rank];
 
   auto current = matrix::outer(a, b);
-  MPI_Allreduce(current.get_ptr(), result.get_ptr(), result.dimension(), MPI_DOUBLE, MPI_SUM, comm);
+  mpi_timer(MPI_Allreduce, current.get_ptr(), result.get_ptr(), result.dimension(), MPI_DOUBLE, MPI_SUM, comm);
 }
 
 } // namespace impls::allreduce

--- a/code/src/util.cpp
+++ b/code/src/util.cpp
@@ -22,9 +22,8 @@ std::vector<vector> get_random_vectors(uint64_t seed, int n, int p) {
   return out;
 }
 
-int64_t timer(std::function<void(void)> fun) {
-  auto start = MPI_Wtime();
+int64_t timer_run(std::function<void(void)> fun) {
+  timer t;
   fun();
-  auto finish = MPI_Wtime();
-  return static_cast<int64_t>((finish - start) * 1e6);
+  return t.finish();
 }


### PR DESCRIPTION
Any call `MPI_*(a, b, c)` inside an implementation should now be called as `mpi_timer(MPI_*, a, b, c)`. This runs the given function and also measures how long the function takes.