### PR TITLE
Add flags per build type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        build_type: ["Release", "Debug"]
     env:
       CXX: "g++"
-      BUILD_TYPE: "Release"
-      BUILD_DIR: "${{ github.workspace}}/code/build"
+      BUILD_TYPE: ${{ matrix.build_type }}
+      BUILD_DIR: "${{ github.workspace }}/code/build"
       MAKEFLAGS: "-j4"
       COLOR: "ON"
       CXXFLAGS: "-Werror"
@@ -45,6 +48,7 @@ jobs:
           cd "$BUILD_DIR"
           impls=("allreduce" "allgather" "allreduce-butterfly" "allgather-async")
           for i in "${impls[@]}"; do
-            echo "$i"
-            mpirun ./main -c -n 1000 -m 2000 -i "$i"
+            echo -e "\e[33${i}\e[0m"
+            mpirun -np 1 ./main -c -n 1000 -m 2000 -i "$i"
+            mpirun -np 2 ./main -c -n 1000 -m 2000 -i "$i"
           done

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -7,9 +7,29 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 message(STATUS "Using compiler: ${CMAKE_CXX_COMPILER_ID}")
 
-# Only add GCC flags if using GCC
-set(cxx_flags -Wall -Wextra -Wpedantic -Wsuggest-override -O3 -funroll-loops)
-set(cxx_linker_flags ${cxx_flags})
+# Set default build type if not specified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+  message(STATUS "No build type specified; using ${CMAKE_BUILD_TYPE}")
+endif()
+string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
+
+list(APPEND cxx_base -Wall -Wextra -Wpedantic -Wsuggest-override)
+list(APPEND cxx_debug -DDEBUG -g2)
+list(APPEND cxx_sanitize -O0 -g -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls)
+
+list(APPEND cxx_linker_base "")
+
+list(APPEND cxx_flags ${cxx_base})
+list(APPEND cxx_linker_flags ${cxx_linker_base})
+
+if (CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG")
+  list(APPEND cxx_flags ${cxx_debug})
+elseif (CMAKE_BUILD_TYPE_UPPER STREQUAL "SANITIZE")
+  list(APPEND cxx_flags ${cxx_sanitize})
+endif()
+
+list(APPEND cxx_linker_flags ${cxx_flags})
 
 set(MAIN_SOURCES
         src/vector.cpp


### PR DESCRIPTION
The default build type is `Release`. This basically enables `-O3` and disables assertions (`-DNDEBUG`).

CI now also runs with both Debug and Release.