### PR TITLE
Make all 'allreduce-native-*' implementation names run allreduce

### DIFF
--- a/code/src/main.cpp
+++ b/code/src/main.cpp
@@ -131,6 +131,8 @@ static std::unique_ptr<dsop> get_impl(const std::string& name, Args&&... args) {
     return std::make_unique<impls::allgather::allgather>(std::forward<Args>(args)...);
   } else if (name == "allgather-async") {
     return std::make_unique<impls::allgather_async::allgather_async>(std::forward<Args>(args)...);
+  } else if (name.rfind("allreduce-native-", 0) == 0) {
+    return std::make_unique<impls::allreduce::allreduce>(std::forward<Args>(args)...);
   } else {
     throw std::runtime_error("Unknown implementation '" + name + "'");
   }


### PR DESCRIPTION
Needed because if we want to run a fixed allreduce implementation, this
cannot be done in the C code but on the commandline.

The C code just runs the allreduce implementation and the runner has to
ensure that the corresponding allreduce implementation is selected.

@elwin FYI wenn de allreduce algo fixiersch, nenn d implementation eifach `alreduce-native-<NAME>`.